### PR TITLE
added return to a custom response

### DIFF
--- a/curiefense/curieproxy/lua/session_nginx.lua
+++ b/curiefense/curieproxy/lua/session_nginx.lua
@@ -39,7 +39,7 @@ local function custom_response(handle, action_params)
 
     if block_mode then
         if action_params["content"] then handle.say(action_params["content"]) end
-        handle.exit(handle.HTTP_OK)
+        return handle.exit(handle.HTTP_OK)
     end
 
 end


### PR DESCRIPTION
following recommendation from https://github.com/openresty/lua-nginx-module#ngxexit

> Also note that this method call terminates the processing of the current request and that it is recommended that a 
> coding style that combines this method call > with the return statement, i.e., `return ngx.exit(...)` be used to reinforce 
> the fact that the request processing is being terminated.